### PR TITLE
improvement/add client to reuse HttpClient and URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/qiyihuang/messenger
 
 go 1.16
 
-require github.com/stretchr/testify v1.7.0
+require github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/validator.go
+++ b/validator.go
@@ -102,7 +102,7 @@ func validateEmbed(e Embed) error {
 func validateURL(url string) error {
 	const webhookPrefix = "https://discord.com/api/webhooks/"
 	if !strings.HasPrefix(url, webhookPrefix) {
-		return errors.New("URL invalid")
+		return errors.New("invalid webhook URL")
 	}
 	return nil
 }
@@ -129,16 +129,12 @@ func validateMessage(m Message) error {
 }
 
 // validateRequest calls validateURL and validateMessage to check validity of a Request.
-func validateRequest(r Request) error {
-	if err := validateURL(r.url); err != nil {
-		return err
-	}
-
-	if len(r.messages) == 0 {
+func validateMessages(msgs []Message) error {
+	if len(msgs) == 0 {
 		return errors.New("request must have a least 1 message")
 	}
 
-	for _, msg := range r.messages {
+	for _, msg := range msgs {
 		if err := validateMessage(msg); err != nil {
 			return err
 		}

--- a/validator_test.go
+++ b/validator_test.go
@@ -2,7 +2,6 @@ package messenger
 
 import (
 	"errors"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -220,7 +219,7 @@ func TestValidateURL(t *testing.T) {
 
 		err := validateURL(url)
 
-		require.Equal(t, errors.New("URL invalid"), err, "Invalid failed")
+		require.Equal(t, errors.New("invalid webhook URL"), err, "Invalid failed")
 	})
 
 	t.Run("Pass", func(t *testing.T) {
@@ -276,23 +275,11 @@ func TestValidateMessage(t *testing.T) {
 	})
 }
 
-func TestValidateRequest(t *testing.T) {
-	t.Run("URL error", func(t *testing.T) {
-		msgs := []Message{{Content: "Ok"}}
-		url := "wrong"
-		req := Request{msgs, url, http.DefaultClient}
-
-		err := validateRequest(req)
-
-		require.EqualError(t, err, "URL invalid")
-	})
-
+func TestValidateMessages(t *testing.T) {
 	t.Run("No message", func(t *testing.T) {
 		msgs := []Message{}
-		url := "https://discord.com/api/webhooks/"
-		req := Request{msgs, url, http.DefaultClient}
 
-		err := validateRequest(req)
+		err := validateMessages(msgs)
 
 		require.EqualError(t, err, "request must have a least 1 message")
 
@@ -300,20 +287,16 @@ func TestValidateRequest(t *testing.T) {
 
 	t.Run("Message error", func(t *testing.T) {
 		msgs := []Message{{Content: "Ok"}, {}} // Failed on second make sure it loops.
-		url := "https://discord.com/api/webhooks/"
-		req := Request{msgs, url, http.DefaultClient}
 
-		err := validateRequest(req)
+		err := validateMessages(msgs)
 
 		require.EqualError(t, err, "Message must have either content or embeds")
 	})
 
 	t.Run("Pass", func(t *testing.T) {
 		msgs := []Message{{Content: "Ok"}}
-		url := "https://discord.com/api/webhooks/"
-		req := Request{msgs, url, http.DefaultClient}
 
-		err := validateRequest(req)
+		err := validateMessages(msgs)
 
 		require.Equal(t, nil, err, "Message error failed")
 	})


### PR DESCRIPTION
- improvement/use client to reuse HttpClient and URL
- chore/bump testify

Deleted "Request" type. "Send" method is now under "Client" type. Caller can reuse "Client" easier than rather than building one off "Request" to send. 